### PR TITLE
Rename 6811.c functions to be more descriptive

### DIFF
--- a/Core/Inc/6811.h
+++ b/Core/Inc/6811.h
@@ -42,29 +42,29 @@ void Wakeup_Idle(void);
 
 void Wakeup_Sleep(void);
 
-LTC_SPI_StatusTypeDef Read_Cell_Volt(uint16_t *read_voltages);
+LTC_SPI_StatusTypeDef LTC_getCellVoltages(uint16_t *read_voltages);
 
 /* write to PWM register to control balancing functionality */
-void LTC6811_WRPWM(uint8_t total_ic, uint8_t pwm);
+void LTC_writePWM(uint8_t total_ic, uint8_t pwm);
 
-void LTC6811_WRCFG(uint8_t total_ic, //The number of ICs being written to
+void LTC_writeCFG(uint8_t total_ic, //The number of ICs being written to
 		uint8_t config[][6] //A two dimensional array of the configuration data that will be written
 		);
 
-void LTC_WRCOMM(uint8_t total_ic, //The number of ICs being written to
+void LTC_SPI_writeCommunicationSetting(uint8_t total_ic, //The number of ICs being written to
 		uint8_t comm[6] //A two dimensional array of the comm data that will be written
 		);
 
-void LTC_STCOMM(uint8_t len);
+void LTC_SPI_requestData(uint8_t len);
 
-LTC_SPI_StatusTypeDef Read_Cell_Temps(uint16_t *read_auxiliary);
+LTC_SPI_StatusTypeDef LTC_readCellTemperatures(uint16_t *read_auxiliary);
 
-void LTC_ADCV(uint8_t MD, //ADC Mode
+void LTC_startADCVoltage(uint8_t MD, //ADC Mode
 		uint8_t DCP, //Discharge Permit
 		uint8_t CH //Cell Channels to be measured
 		);
 
-void LTC_ADAX(uint8_t MD, //ADC Mode
+void LTC_startADC_GPIO(uint8_t MD, //ADC Mode
 		uint8_t CHG //GPIO Channels to be measured)
 		);
 

--- a/Core/Src/6811.c
+++ b/Core/Src/6811.c
@@ -33,7 +33,7 @@ void Wakeup_Sleep(void) {
 }
 
 /* Read and store raw cell voltages at uint8_t 2d pointer */
-LTC_SPI_StatusTypeDef Read_Cell_Volt(uint16_t *read_voltages) {
+LTC_SPI_StatusTypeDef LTC_getCellVoltages(uint16_t *read_voltages) {
 	LTC_SPI_StatusTypeDef ret = LTC_SPI_OK;
 	LTC_SPI_StatusTypeDef hal_ret;
 	const uint8_t ARR_SIZE_REG = NUM_DEVICES * REG_LEN;
@@ -87,7 +87,7 @@ LTC_SPI_StatusTypeDef Read_Cell_Volt(uint16_t *read_voltages) {
  * @param total_ic		total count of ic (daisy chain)
  * @param pwm			A two dimensional array of the configuration data that will be written
  */
-void LTC6811_WRPWM(uint8_t total_ic, uint8_t pwm) {
+void LTC_writePWM(uint8_t total_ic, uint8_t pwm) {
 	// NOTE currently chaging this method to only assign a specific PWM to all registers
 
 	// TODO change it back to relying on @param pwm for duty cycle assignment. 
@@ -132,7 +132,7 @@ void LTC6811_WRPWM(uint8_t total_ic, uint8_t pwm) {
 	LTC_nCS_High();
 }
 
-void LTC6811_WRCFG(uint8_t total_ic, //The number of ICs being written to
+void LTC_writeCFG(uint8_t total_ic, //The number of ICs being written to
 		uint8_t config[][6] //A two dimensional array of the configuration data that will be written
 		) {
 	const uint8_t BYTES_IN_REG = 6;
@@ -178,7 +178,7 @@ void LTC6811_WRCFG(uint8_t total_ic, //The number of ICs being written to
  * @param total_ic	The number of ICs being written to
  * @param comm[6]	A two dimensional array of the comm data that will be written
  */
-void LTC_WRCOMM(uint8_t total_ic, uint8_t comm[6]) {
+void LTC_SPI_writeCommunicationSetting(uint8_t total_ic, uint8_t comm[6]) {
 	const uint8_t BYTES_IN_REG = 6;
 	const uint8_t CMD_LEN = 4 + (8 * total_ic);
 	uint16_t comm_pec;
@@ -219,7 +219,7 @@ void LTC_WRCOMM(uint8_t total_ic, uint8_t comm[6]) {
 /**
  * Shifts data in COMM register out over ltc6811 SPI/I2C port
  */
-void LTC_STCOMM(uint8_t len) {
+void LTC_SPI_requestData(uint8_t len) {
 
 	uint8_t cmd[4];
 	uint16_t cmd_pec;
@@ -239,7 +239,7 @@ void LTC_STCOMM(uint8_t len) {
 	LTC_nCS_High();
 }
 
-LTC_SPI_StatusTypeDef Read_Cell_Temps(uint16_t *read_auxiliary) {
+LTC_SPI_StatusTypeDef LTC_readCellTemperatures(uint16_t *read_auxiliary) {
 	LTC_SPI_StatusTypeDef ret = LTC_SPI_OK;
 	LTC_SPI_StatusTypeDef hal_ret;
 	const uint8_t ARR_SIZE_REG = NUM_DEVICES * REG_LEN;
@@ -293,7 +293,7 @@ LTC_SPI_StatusTypeDef Read_Cell_Temps(uint16_t *read_auxiliary) {
 /*
  Starts cell voltage conversion
  */
-void LTC_ADCV(uint8_t MD,  // ADC Mode
+void LTC_startADCVoltage(uint8_t MD,  // ADC Mode
 		uint8_t DCP, // Discharge Permit
 		uint8_t CH   // Cell Channels to be measured
 		) {
@@ -315,7 +315,7 @@ void LTC_ADCV(uint8_t MD,  // ADC Mode
 	LTC_nCS_High();
 }
 
-void LTC_ADAX(uint8_t MD, // ADC Mode
+void LTC_startADC_GPIO(uint8_t MD, // ADC Mode
 		uint8_t CHG // GPIO Channels to be measured)
 		) {
 	uint8_t cmd[4];

--- a/Core/Src/balance.c
+++ b/Core/Src/balance.c
@@ -49,12 +49,12 @@ static uint8_t defaultConfig[8][6] = { { 0xF8, 0x00, 0x00, 0x00, 0x00, 0x20 }, {
 void Start_Balance(uint16_t *read_volt, uint8_t length, uint16_t lowest) {
 	Discharge_Algo(read_volt, NUM_DEVICES, lowest);
 	Wakeup_Sleep();
-	LTC6811_WRCFG(NUM_DEVICES, config);
+	LTC_writeCFG(NUM_DEVICES, config);
 }
 
 void End_Balance(uint8_t *faults) {
 	Wakeup_Sleep();
-	LTC6811_WRCFG(NUM_DEVICES, defaultConfig);
+	LTC_writeCFG(NUM_DEVICES, defaultConfig);
 	*faults |= 0b00000010;
 }
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -166,15 +166,15 @@ int main(void)
 //				printf(" Cell: %d, Temp: %d\n", i, modPackInfo.cell_temp[i]);
 	}
 	if (indexpause == 8) {
-		LTC_WRCOMM(NUM_DEVICES, BMS_MUX_PAUSE[0]);
-		LTC_STCOMM(2);
+		LTC_SPI_writeCommunicationSetting(NUM_DEVICES, BMS_MUX_PAUSE[0]);
+		LTC_SPI_requestData(2);
 		tempindex = 8;
 		indexpause = NUM_THERM_PER_MOD;
 //				HAL_Delay(1); //this delay is for stablize mux
 	}
 	else if (indexpause == NUM_THERM_PER_MOD) {
-		LTC_WRCOMM(NUM_DEVICES, BMS_MUX_PAUSE[1]);
-		LTC_STCOMM(2);
+		LTC_SPI_writeCommunicationSetting(NUM_DEVICES, BMS_MUX_PAUSE[1]);
+		LTC_SPI_requestData(2);
 		indexpause = 8;
 		tempindex = 0;
 //				HAL_Delay(1); //this delay is for stablize mux
@@ -223,15 +223,15 @@ int main(void)
 //				printf(" Cell: %d, Temp: %d\n", i, modPackInfo.cell_temp[i]);
 			}
 			if (indexpause == 8) {
-				LTC_WRCOMM(NUM_DEVICES, BMS_MUX_PAUSE[0]);
-				LTC_STCOMM(2);
+				LTC_SPI_writeCommunicationSetting(NUM_DEVICES, BMS_MUX_PAUSE[0]);
+				LTC_SPI_requestData(2);
 				tempindex = 8;
 				indexpause = NUM_THERM_PER_MOD;
 //				HAL_Delay(1); //this delay is for stablize mux
 			}
 			else if (indexpause == NUM_THERM_PER_MOD) {
-				LTC_WRCOMM(NUM_DEVICES, BMS_MUX_PAUSE[1]);
-				LTC_STCOMM(2);
+				LTC_SPI_writeCommunicationSetting(NUM_DEVICES, BMS_MUX_PAUSE[1]);
+				LTC_SPI_requestData(2);
 				indexpause = 8;
 				tempindex = 0;
 //				HAL_Delay(1); //this delay is for stablize mux

--- a/Core/Src/module.c
+++ b/Core/Src/module.c
@@ -41,20 +41,20 @@ void Get_Actual_Temps(uint8_t dev_idx, uint8_t tempindex, uint16_t *actual_temp,
 
 void Read_Volt(uint16_t *read_volt) {
 //	printf("volt start\n");
-	LTC_ADCV(MD_NORMAL, DCP_DISABLED, CELL_CH_ALL);//ADC mode: MD_FILTERED, MD_NORMAL, MD_FAST
+	LTC_startADCVoltage(MD_NORMAL, DCP_DISABLED, CELL_CH_ALL);//ADC mode: MD_FILTERED, MD_NORMAL, MD_FAST
 	HAL_Delay(NORMAL_DELAY);	//FAST_DELAY, NORMAL_DELAY, FILTERD_DELAY;
-	Read_Cell_Volt((uint16_t*) read_volt);
+	LTC_getCellVoltages((uint16_t*) read_volt);
 //	printf("volt end\n");
 }
 
 void Read_Temp(uint8_t tempindex, uint16_t *read_temp, uint16_t *read_auxreg) {
 //	printf("Temperature read start\n");
-	LTC_WRCOMM(NUM_DEVICES, BMS_THERM[tempindex]);
-	LTC_STCOMM(2);
+	LTC_SPI_writeCommunicationSetting(NUM_DEVICES, BMS_THERM[tempindex]);
+	LTC_SPI_requestData(2);
 	//end sending to mux to read temperatures
-	LTC_ADAX(MD_FAST, 1); //ADC mode: MD_FILTERED, MD_NORMAL, MD_FAST
+	LTC_startADC_GPIO(MD_FAST, 1); //ADC mode: MD_FILTERED, MD_NORMAL, MD_FAST
 	HAL_Delay(FAST_DELAY); //FAST_DELAY, NORMAL_DELAY, FILTERD_DELAY;
-	if (!Read_Cell_Temps((uint16_t*) read_auxreg)) // Set to read back all aux registers
+	if (!LTC_readCellTemperatures((uint16_t*) read_auxreg)) // Set to read back all aux registers
 			{
 		for (uint8_t dev_idx = 0; dev_idx < NUM_DEVICES; dev_idx++) {
 			//Wakeup_Idle();


### PR DESCRIPTION
Rename `6811.c` functions to be more descriptive and follow the `Component_functionAction()` format.