### PR TITLE
Fix bug where SOC fails to decrease at low currents

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -70,7 +70,7 @@ typedef struct batteryModule {
 	uint16_t hvsens_pack_voltage;
 	uint16_t read_auxreg[NUM_AUXES];
 	uint16_t balance_status[NUM_DEVICES];
-    uint16_t soc;
+    uint32_t soc; // microamps!!!!!
     uint32_t current;
     uint16_t dew_point[NUM_DEVICES];
 } batteryModule;

--- a/Core/Src/can.c
+++ b/Core/Src/can.c
@@ -306,10 +306,11 @@ void CAN_Send_Safety_Checker(CANMessage *buffer, batteryModule *batt, uint8_t *f
 void CAN_Send_SOC(CANMessage *buffer, batteryModule *batt,
                   uint16_t max_capacity) {
 	uint32_t CAN_ID = (uint32_t)CAN_ID_SOC;
-    uint8_t percent = (uint8_t)((float) batt->soc * 100 / (float) max_capacity);
+    uint8_t percent = (uint8_t)((float) (batt->soc / 1000) * 100 / (float) max_capacity);  // 1000 for micro->milli
+    uint16_t soc = (uint16_t) (batt->soc / 1000);
     Set_CAN_Id(buffer, CAN_ID);
-	buffer->socBuffer[0] = batt->soc;
-	buffer->socBuffer[1] = batt->soc >> 8;
+	buffer->socBuffer[0] = soc & 0xFF;
+	buffer->socBuffer[1] = (soc >> 8) & 0xFF;
     buffer->socBuffer[2] = percent;
     buffer->socBuffer[3] = batt->current & 0xFF;
     buffer->socBuffer[4] = (batt->current >> 8) & 0xFF;

--- a/Core/Src/soc.c
+++ b/Core/Src/soc.c
@@ -43,13 +43,13 @@ void SOC_getInitialCharge(batteryModule *batt) {
 
     switch (selectTemp) {
         case 0:
-            batt->soc = SOC_getChargeData0C((uint16_t) voltage) * NUM_DEVICES;
+            batt->soc = SOC_getChargeData0C((uint16_t) voltage) * NUM_DEVICES * 1000;
             break;
         case 25:
-            batt->soc = SOC_getChargeData25C((uint16_t) voltage) * NUM_DEVICES;
+            batt->soc = SOC_getChargeData25C((uint16_t) voltage) * NUM_DEVICES * 1000;
             break;
         default:
-            batt->soc = SOC_getChargeData40C((uint16_t) voltage) * NUM_DEVICES;
+            batt->soc = SOC_getChargeData40C((uint16_t) voltage) * NUM_DEVICES * 1000;
             break;
     }
 }
@@ -69,8 +69,9 @@ void SOC_updateCurrent(batteryModule *batt) {
 void SOC_updateCharge(batteryModule *batt, uint32_t elapsed_time) {
 
 	HAL_ADCEx_Calibration_Start(&hadc2);
-    SOC_updateCurrent(batt);
-    batt->soc -= (uint16_t)(batt->current * (float)(elapsed_time / 3600000.0f));
+	SOC_updateCurrent(batt);
+    batt->soc -= (1000 * batt->current * (float)(elapsed_time / 3600000.0f));
+    printf("%d", batt->soc);
 }
 
 uint16_t SOC_searchCapacity(uint16_t data[][2], uint16_t target, uint16_t size) {


### PR DESCRIPTION
Previously, when multiplying the current (mA) by time (hr), the resulting capacity decrease would be truncated because it was so small. Now, soc is stored as a µA, fixing the truncation issue.

Note: Figure out a better way to sort datatypes when refactoring in the future