### PR TITLE
Fix SoC Initialization 97% Bug

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -106,7 +106,7 @@ void Error_Handler(void);
 /* USER CODE END EFP */
 
 /* Private defines -----------------------------------------------------------*/
-#define Shunt_PIN_FOR_2A_Pin GPIO_PIN_2
+#define Shunt_PIN_FOR_2A_Pin GPIO_PIN_3
 #define Shunt_PIN_FOR_2A_GPIO_Port GPIOC
 #define LTC_nCS_Pin GPIO_PIN_4
 #define LTC_nCS_GPIO_Port GPIOA

--- a/Core/Src/adc.c
+++ b/Core/Src/adc.c
@@ -99,7 +99,7 @@ void MX_ADC2_Init(void)
 
   /** Configure Regular Channel
   */
-  sConfig.Channel = ADC_CHANNEL_12;
+  sConfig.Channel = ADC_CHANNEL_13;
   sConfig.Rank = ADC_REGULAR_RANK_1;
   sConfig.SamplingTime = ADC_SAMPLETIME_1CYCLE_5;
   if (HAL_ADC_ConfigChannel(&hadc2, &sConfig) != HAL_OK)

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -154,6 +154,26 @@ int main(void)
 
 	Wakeup_Sleep();
 
+    Read_Volt(modPackInfo.cell_volt);
+
+    for (uint8_t i = 0; i < 8; i++) {
+//				HAL_Delay(300);
+        Read_Temp(i, modPackInfo.cell_temp, modPackInfo.read_auxreg);
+
+//				printf(" Cell: %d, Temp: %d\n", i, modPackInfo.cell_temp[i]);
+    }
+    LTC_SPI_writeCommunicationSetting(NUM_DEVICES, BMS_MUX_PAUSE[0]);
+    LTC_SPI_requestData(2);
+//				HAL_Delay(1); //this delay is for stablize mux
+    for (uint8_t i = 8; i < NUM_THERM_PER_MOD; i++) {
+//				HAL_Delay(300);
+        Read_Temp(i, modPackInfo.cell_temp, modPackInfo.read_auxreg);
+
+//				printf(" Cell: %d, Temp: %d\n", i, modPackInfo.cell_temp[i]);
+    }
+    LTC_SPI_writeCommunicationSetting(NUM_DEVICES, BMS_MUX_PAUSE[1]);
+    LTC_SPI_requestData(2);
+//				HAL_Delay(1); //this delay is for stablize mux
     Balance_init(modPackInfo.balance_status);
 
 	SOC_getInitialCharge(&modPackInfo);


### PR DESCRIPTION
Previously, SoC would always be initialized at 97% because, even though initialization requires voltage and temperature reading, we didn't do the reading. As a result, the default voltage was 6.5535V, leading to the value on the LUT to be 97% SoC. This PR fixes the bug by reading voltage and temperature before initialization.

Also updates shunt pin for new revision